### PR TITLE
🔧 fix: ユーザー名にハイフンを含む文字入力を許可

### DIFF
--- a/src/scenes/MainMenuScene.js
+++ b/src/scenes/MainMenuScene.js
@@ -770,8 +770,8 @@ export class MainMenuScene extends Scene {
                 default:
                     // 文字入力
                     if (event.key.length === 1 && this.usernameInput.length < 10) {
-                        // 英数字、ひらがな、カタカナ、漢字のみ許可
-                        if (/[a-zA-Z0-9ぁ-んァ-ヶ一-龯]/.test(event.key)) {
+                        // 英数字、ひらがな、カタカナ、漢字、ハイフン、アンダースコア、ピリオドを許可
+                        if (/[a-zA-Z0-9ぁ-んァ-ヶ一-龯\-_.　]/.test(event.key)) {
                             this.usernameInput += event.key;
                         }
                     }


### PR DESCRIPTION
## Summary
- ユーザー名入力でハイフン（-）が入力できない問題を修正
- 正規表現を更新してハイフン、アンダースコア、ピリオド、全角スペースを許可
- MainMenuScene.jsの入力バリデーション部分を修正

## 変更内容
- `/[a-zA-Z0-9ぁ-んァ-ヶ一-龯]/` → `/[a-zA-Z0-9ぁ-んァ-ヶ一-龯\-_.　]/`
- 英数字、ひらがな、カタカナ、漢字に加えて以下の文字を許可：
  - ハイフン（-）
  - アンダースコア（_）
  - ピリオド（.）
  - 全角スペース（　）

## Test plan
- [x] ローカルサーバーでユーザー名入力画面を開く
- [x] ハイフンを含むユーザー名（例：test-user）の入力を確認
- [x] その他の許可文字の入力を確認
- [x] 10文字制限が正常に動作することを確認

## 関連Issue
Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)