### PR TITLE
🐛 fix: AudioWorkletのサポートチェックを修正

### DIFF
--- a/src/audio/effects/AudioContextManager.js
+++ b/src/audio/effects/AudioContextManager.js
@@ -67,6 +67,14 @@ export class AudioContextManager {
             
             // AudioWorklet サポート
             this.browserSupport.audioWorklet = !!(window.AudioContext && AudioContext.prototype.audioWorklet);
+            // 修正箇所: インスタンスを作成してからプロパティをチェック
+            if (this.browserSupport.audioContext) {
+                const tempAudioContext = new (window.AudioContext || window.webkitAudioContext)();
+                this.browserSupport.audioWorklet = !!tempAudioContext.audioWorklet;
+                tempAudioContext.close(); // インスタンスを閉じる
+            } else {
+                this.browserSupport.audioWorklet = false;
+            }
             
             // MediaDevices サポート
             this.browserSupport.mediaDevices = !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);


### PR DESCRIPTION
## 概要
AudioContextManagerのcheckBrowserSupport()メソッドで、AudioWorkletのサポートチェックが適切に動作しない問題を修正しました。

## 関連Issue
Fixes #132

## 変更内容
- AudioContextのインスタンスを作成してからaudioWorkletプロパティをチェックするように修正
- チェック後にAudioContextインスタンスを適切にclose()で破棄
- より正確なブラウザサポート検出を実現

## 技術的詳細
既存のコードでは`AudioContext.prototype.audioWorklet`をチェックしていましたが、実際には`AudioContext`インスタンスの`audioWorklet`プロパティをチェックする必要がありました。

### 修正前
```javascript
this.browserSupport.audioWorklet = \!\!(window.AudioContext && AudioContext.prototype.audioWorklet);
```

### 修正後
```javascript
if (this.browserSupport.audioContext) {
    const tempAudioContext = new (window.AudioContext || window.webkitAudioContext)();
    this.browserSupport.audioWorklet = \!\!tempAudioContext.audioWorklet;
    tempAudioContext.close(); // インスタンスを閉じる
} else {
    this.browserSupport.audioWorklet = false;
}
```

## テスト内容
- [x] ローカル環境でゲームが正常に起動することを確認
- [x] AudioWorkletのサポート状況が正しく検出されることを確認
- [x] AudioContextが適切にクリーンアップされることを確認

## 影響範囲
- 音声初期化処理の安定性向上
- ブラウザ互換性の改善

🤖 Generated with [Claude Code](https://claude.ai/code)